### PR TITLE
fix: honor defined env variables in build script

### DIFF
--- a/kos/samba/cross-build.sh
+++ b/kos/samba/cross-build.sh
@@ -6,15 +6,15 @@ BUILD=$(pwd)/build
 mkdir -p $BUILD && cd $BUILD
 
 export LANG=C
-export TARGET="aarch64-kos"
+export TARGET=${TARGET:-"aarch64-kos"}
 export PKG_CONFIG=""
-export SDK_PREFIX="/opt/KasperskyOS-Community-Edition-1.1.0.24"
+export SDK_PREFIX=${SDK_PREFIX:-"/opt/KasperskyOS-Community-Edition-1.1.0.24"}
 export INSTALL_PREFIX=$SDK_PREFIX/sysroot-$TARGET
 BUILD_SIM_TARGET="y"
 export PATH="$SDK_PREFIX/toolchain/bin:$PATH"
 
-export BUILD_WITH_CLANG=
-export BUILD_WITH_GCC=
+export BUILD_WITH_CLANG=${BUILD_WITH_CLANG:-}
+export BUILD_WITH_GCC=${BUILD_WITH_GCC:-}
 
 TOOLCHAIN_SUFFIX=""
 


### PR DESCRIPTION
This commit updates build script (`./kos/samba/cross-build.sh`) to honor already defined env variables, like `SDK_PREFIX` and `TARGET`, to allow build with different SDKs and targets:
```sh
export SDK_PREFIX=/opt/KasperskyOS-CE-custom-path/
export TARGET=x86_64-pc-kos
./kos/samba/cross-build.sh # x86-64 with custom sdk
```