### PR TITLE
fix: correct .gitmodules and submodule filetype

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "openssl"]
+[submodule "third_party/openssl"]
 	path = third_party/openssl
 	url = https://github.com/openssl/openssl.git


### PR DESCRIPTION
This commit updates the files (.gitmodules, third_party/openssl) to fix not recognizing them as an honest .git submodule.